### PR TITLE
fix: closing tag for h1

### DIFF
--- a/projects/view-weather-with-html-css-js/view-weather-with-html-css-js.mdx
+++ b/projects/view-weather-with-html-css-js/view-weather-with-html-css-js.mdx
@@ -126,7 +126,7 @@ Next, let's add the following HTML inside the `<body>` element:
 <body>
 <main>
   <section id="weather-wrapper">
-    <h1>Weather App</h2>
+    <h1>Weather App</h1>
     <div id="weather-search">
      <input id="search" type="text" placeholder="Search by city" />
       <input id="submit" type="submit" onclick="fetchWeather()" value="Search" />


### PR DESCRIPTION
## Fix: Closing tag for `<h1>`
- This PR addresses a bug that occurs on [**line 129**](https://github.com/codedex-io/projects/blob/25439ae4868ec8efc3987eac158684547df589c5/projects/view-weather-with-html-css-js/view-weather-with-html-css-js.mdx#L129C25-L129C25) of [view-weather-with-html-css-js.mdx](https://github.com/codedex-io/projects/blob/main/projects/view-weather-with-html-css-js/view-weather-with-html-css-js.mdx#L129C25-L129C25).

### Changes:
- Added the correct closing tag type for `<h1>` which is `</h1>`.

### Screenshot of change:
<img width="329" alt="image" src="https://github.com/codedex-io/projects/assets/140430987/36532ab8-7d91-41a5-b605-0f16d7dab37c">

### Related issues:
- This PR closes #115.