### PR TITLE
fix: remove random backticks

### DIFF
--- a/projects/view-weather-with-html-css-js/view-weather-with-html-css-js.mdx
+++ b/projects/view-weather-with-html-css-js/view-weather-with-html-css-js.mdx
@@ -341,7 +341,7 @@ In this final step, we are going to write this `fetchWeather()` function! Afterw
 Let's open our **script.js** file and start by defining a new `fetchWeather()` function:
 
 ```js
-function fetchWeather()` {
+function fetchWeather() {
 
 }
 ```
@@ -349,7 +349,7 @@ function fetchWeather()` {
 This function takes no parameters. Next, let's define a few global variables inside the function:
 
 ```js
-function fetchWeather()` {
+function fetchWeather() {
   let searchInput = document.getElementById("search").value;
   const weatherDataSection = document.getElementById("weather-data");
   weatherDataSection.style.display = "block";


### PR DESCRIPTION
## Fix: Random backticks in function examples
- This PR fixes a bug caused by random backticks added to `2` example functions.

**Bug:**
```python
function fetchWeather()`
```
### Changes:
- Removed the backticks found in two of the function examples.

### Related issues:
- This PR closes #117.