### PR TITLE
Documentation: Fixed ading to adding (line 127), corrected grammar in lines 72,80, 281, and 297

### DIFF
--- a/projects/detect-hotdog-with-hugging-face/detect-hotdog-with-hugging-face.mdx
+++ b/projects/detect-hotdog-with-hugging-face/detect-hotdog-with-hugging-face.mdx
@@ -69,7 +69,7 @@ python -m pip install flask
 
 ## Install Dotenv
 
-We also have install the `dotenv` library which we use to load environment variables.  You can find the package link [here](https://pypi.org/project/python-dotenv/).
+We also have to install the `dotenv` library which we use to load environment variables.  You can find the package link [here](https://pypi.org/project/python-dotenv/).
 
 ```shell
 pip install python-dotenv
@@ -77,7 +77,7 @@ pip install python-dotenv
 
 ## Install Requests
 
-The last package we have to add is `requests` which is a library to handle http requests. You can find the package link [here](https://pypi.org/project/requests/).
+The last package we need to add is `requests` which is a library to handle http requests. You can find the package link [here](https://pypi.org/project/requests/).
 
 ```shell
 pip install python-dotenv
@@ -124,7 +124,7 @@ Create an `.env` file at the root of the project. This is where we will place ou
 
 ## Add variables to the .env file
 
-Open the `.env` file and add `HUGGING_FACE_API_URL= `and `HUGGING_FACE_API_KEY=`, ading in your API key and URL. This is where we place the hugging face data to allow us to use hugging face's models. 
+Open the `.env` file and add `HUGGING_FACE_API_URL= `and `HUGGING_FACE_API_KEY=`, adding in your API key and URL. This is where we place the hugging face data to allow us to use hugging face's models. 
 
 ```shell
 HUGGING_FACE_API_URL=https://api-inference.huggingface.co/models/julien-c/hotdog-not-hotdog
@@ -278,7 +278,7 @@ python3 web.py
 
 ## Bonus implement the successor Not Bannana.
 
-The not\_hot\_dog model was originally created by Julien C at https://huggingface.co/julien-c. Now the fun thing is you can actually train your own version of the model which we can save for another time, but in the meantime you can replace your `HUGGING_FACE_API_URL` with one I created for not bannanas. Just upload pictures of Bannanas instead of hot dogs.
+The not\_hot\_dog model was originally created by Julien C at https://huggingface.co/julien-c. Now the fun thing is you can actually train your own version of the model, which we can save for another time, but in the meantime you can replace your `HUGGING_FACE_API_URL` with one I created for not bannanas. Just upload pictures of Bannanas instead of hot dogs.
 
 ## Replace your Url
 
@@ -294,7 +294,7 @@ Now run the project again and upload bannanas or anything not bannanas.
 
 You did it, you are a Silicon Valley Legend just like Jian Yang, and now we have two APIs that can detect whether something is not a hot dog or is not a bannana.  If you keep this innovation up you will be raising money from Top VCs like Peter Gregory at Raviga and be on your way to be the next Hooli or Pied Piper.  Thanks for reading!
 
-Hope you enjoyed the tutorial. If you have any questions, reach out to me on my linkedin [andrewryanvanbeek](https://www.linkedin.com/in/andrewryanvanbeek).  Also if you interested in following what I am personally building check out [Dev-Docs](https://dev-docs.typedream.app/).
+Hope you enjoyed the tutorial. If you have any questions, reach out to me on my linkedin [andrewryanvanbeek](https://www.linkedin.com/in/andrewryanvanbeek).  Also if you are interested in following what I am personally building check out [Dev-Docs](https://dev-docs.typedream.app/).
 
 ## More Resources
 


### PR DESCRIPTION
# Corrected spelling and grammar mistakes in documentation

 

This pull request addresses several spelling and grammar errors in the documentation to improve its overall quality and readability.

## Changes:

####  Spelling: Corrected "ading" to "adding" on line 127.
#### Grammar: Corrected grammar in the following lines:
- Line 72: "We also have install the dotenv library" to "We also have to install the dotenv library"
- Line 80: "The last package we have to add is requests" to "The last package we need to add is requests"
- Line 281: "you can actually train your own version of the model which we can save for another time" to "you can actually train your own version of the model, which we can save for another time"
- Line 297: "if you interested in following what I am personally building" to "if you are interested in following what I am personally building"

### Testing:

Manual: Verified that the corrected spelling and grammar improve the clarity and professionalism of the documentation.