### PR TITLE
Fixed Missing comma in names_and_emails list

### DIFF
--- a/projects/automate-secret-santa-emails-with-smtp/secret_santa.py
+++ b/projects/automate-secret-santa-emails-with-smtp/secret_santa.py
@@ -22,7 +22,7 @@ Remember to spend 10$-20$ on your gift, but don't stress about it being the perf
 
 names_list = ['Sonny', 'Dharma', 'Malcolm', 'Jerry', 'Asiqur', 'Rose', 'Lillian']
 names_and_emails = [
-  ['Asiqur', 'asiqur@codedex.io']
+  ['Asiqur', 'asiqur@codedex.io'],
   ['Dharma', 'dharma@codedex.io'],
   ['Jerry', 'jerry@codedex.io'],
   ['Lillian', 'lillian@codedex.io'],


### PR DESCRIPTION
## Missing comma in names_and_emails list

### **Fixed**

- Issue with the secret_santa.py where there was a missing comma in names_and_emails list causing a SyntaxWarning Error.

### **Changes**

- added a comma to the list on line 25.
