### PR TITLE
Function Missing a letter & Removed Continue

### DIFF
--- a/projects/build-pong-with-pygame/main.py
+++ b/projects/build-pong-with-pygame/main.py
@@ -87,7 +87,6 @@ def main():
           if event.key == pygame.K_SPACE:
             started = True
 
-       continue
 
     '''
     get the time elapse between now and the last frame
@@ -164,7 +163,7 @@ def main():
     # do the same thing with the bottom
     if ball_rect.bottom > SCREEN_HEIGHT - ball_rect.height:
       ball_accel_y *= -1
-      ball_rect.top = SCREEN_HEIGHT - ball_rect.heigh
+      ball_rect.top = SCREEN_HEIGHT - ball_rect.height
 
     # if the ball goes out of bounds, end the game 
     if ball_rect.left <= 0 or ball_rect.left >= SCREEN_WIDTH:


### PR DESCRIPTION
-  ball_rect.heigh missing letter t, should be ball_rect.height

- continue is removed here to prevent skipping other parts of the loop. In the pygame event loop, using continue immediately after pygame.display.flip() causes the rest of the loop's code to be skipped.

