### PR TITLE
missing comma

### DIFF
--- a/projects/automate-secret-santa-emails-with-smtp/secret_santa.py
+++ b/projects/automate-secret-santa-emails-with-smtp/secret_santa.py
@@ -22,7 +22,7 @@ Remember to spend 10$-20$ on your gift, but don't stress about it being the perf
 
 names_list = ['Sonny', 'Dharma', 'Malcolm', 'Jerry', 'Asiqur', 'Rose', 'Lillian']
 names_and_emails = [
-  ['Asiqur', 'asiqur@codedex.io']
+  ['Asiqur', 'asiqur@codedex.io'],
   ['Dharma', 'dharma@codedex.io'],
   ['Jerry', 'jerry@codedex.io'],
   ['Lillian', 'lillian@codedex.io'],


### PR DESCRIPTION
The missing comma after ['Asiqur', 'asiqur@codedex.io'] caused a syntax error.