### PR TITLE
Updated the MDX for the last PR #158

### DIFF
--- a/projects/build-pong-with-pygame/build-pong-with-pygame.mdx
+++ b/projects/build-pong-with-pygame/build-pong-with-pygame.mdx
@@ -238,7 +238,6 @@ if not started:
       if event.key == pygame.K_SPACE:
         started = True
 
-   continue
 ```
 
 **NOTE**: when looking at the next part of the code, please keep in mind that that PyGame coordinates place (0, 0) at the top-left corner of the screen, and that increasing x means going to the right, and increasing y means going down.


### PR DESCRIPTION
Removed `continue` to allow paddle movement, ball position, and other updates to occur every frame. In the original loop, there was a continue statement after checking for the start event. This statement was causing the loop to skip the remaining code every time it ran, which prevented necessary updates like paddle and ball movement, collision checks, and display refreshes. Removing this continue ensures the game loop runs each frame completely.

